### PR TITLE
Use nanoseconds as time base

### DIFF
--- a/examples/blink-platformio-zephyr/platformio.ini
+++ b/examples/blink-platformio-zephyr/platformio.ini
@@ -45,5 +45,5 @@ board = nrf52840_dk
 framework = zephyr
 lib_deps =
   https://github.com/sedwards-lab/ssm.git
-build_flags = -DSSM_SECOND=16000000L
+build_flags =
 monitor_speed = 115200

--- a/examples/blink-platformio-zephyr/src/main.c
+++ b/examples/blink-platformio-zephyr/src/main.c
@@ -184,7 +184,9 @@ void ssm_tick_thread_body(void *p1, void *p2, void *p3)
 
     ssm_time_t wake = ssm_next_event_time();
     if (wake != SSM_NEVER) {
-      ssm_timer_cfg.ticks = wake;
+      const struct counter_config_info *config =
+          (const struct counter_config_info *)ssm_timer_dev->config;
+      ssm_timer_cfg.ticks = wake * config->freq / NSEC_PER_SEC;
       int r = counter_set_channel_alarm(ssm_timer_dev, 0, &ssm_timer_cfg);
       switch (r) {
       case -ENOTSUP:

--- a/examples/flipfloploopspec-platformio-zephyr/platformio.ini
+++ b/examples/flipfloploopspec-platformio-zephyr/platformio.ini
@@ -43,4 +43,4 @@ board = nrf52840_dk
 framework = zephyr
 lib_deps =
   https://github.com/sedwards-lab/ssm.git
-build_flags = -DSSM_SECOND=16000000L
+build_flags =

--- a/examples/flipfloploopspec-platformio-zephyr/src/main.c
+++ b/examples/flipfloploopspec-platformio-zephyr/src/main.c
@@ -185,7 +185,9 @@ void ssm_tick_thread_body(void *p1, void *p2, void *p3)
 
     ssm_time_t wake = ssm_next_event_time();
     if (wake != SSM_NEVER) {
-      ssm_timer_cfg.ticks = wake;
+      const struct counter_config_info *config =
+          (const struct counter_config_info *)ssm_timer_dev->config;
+      ssm_timer_cfg.ticks = wake * config->freq / NSEC_PER_SEC;
       int r = counter_set_channel_alarm(ssm_timer_dev, 0, &ssm_timer_cfg);
       switch (r) {
       case -ENOTSUP:

--- a/include/ssm.h
+++ b/include/ssm.h
@@ -118,24 +118,18 @@ enum ssm_error_t {
   SSM_PLATFORM_ERROR
 };
 
-#ifndef SSM_SECOND
-/** Ticks in a second
- *
- * Override this according to your platform
- */
-#define SSM_SECOND 1000000000L
-#endif
-
 /** Ticks per nanosecond */
-#define SSM_NANOSECOND  (SSM_SECOND/1000000000L)
+#define SSM_NANOSECOND 1L
 /** Ticks per microsecond */
-#define SSM_MICROSECOND (SSM_SECOND/1000000L)
+#define SSM_MICROSECOND (SSM_NANOSECOND * 1000L)
 /** Ticks per millisecond */
-#define SSM_MILLISECOND (SSM_SECOND/1000L)
+#define SSM_MILLISECOND (SSM_MICROSECOND * 1000L)
+/** Ticks per second */
+#define SSM_SECOND (SSM_MILLISECOND * 1000L)
 /** Ticks per minute */
-#define SSM_MINUTE      (SSM_SECOND*60L)
+#define SSM_MINUTE (SSM_SECOND * 60L)
 /** Ticks per hour */
-#define SSM_HOUR        (SSM_SECOND*3600L)
+#define SSM_HOUR (SSM_MINUTE * 60L)
 
 /** Absolute time; never to overflow. */
 typedef uint64_t ssm_time_t;


### PR DESCRIPTION
Recreated from https://github.com/sedwards-lab/ssm/pull/6

Using a platform-dependent time base causes several headaches for the compiler, since it is unable to predict when time arithmetic might truncate, overflow, or underflow. Furthermore, the runtime library's `SSM_NANOSECOND` will be floored at 0 for any platform whose clock can only run at < 1GHz.

This PR removes the user-overridable `SSM_SECOND` parameter, and instead fixes the time base at nanoseconds, leaving it to the platform-specific part of the runtime to figure out how to sleep for _x_ nanoseconds.