### PR TITLE
Readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # The Sparse Synchronous Model Runtime
 
+![tests](https://github.com/ssm-lang/ssm-runtime/actions/workflows/test.yml/badge.svg?branch=dev)
+[![doc](https://github.com/ssm-lang/ssm-runtime/actions/workflows/doc.yml/badge.svg?branch=dev)](https://ssm-lang.github.io/ssm-runtime)
+[![codecov](https://codecov.io/gh/ssm-lang/ssm-runtime/branch/dev/graph/badge.svg?token=TYCPPY7Y92)](https://codecov.io/gh/ssm-lang/ssm-runtime)
+
 The Sparse Synchronous Model (SSM) is a deterministic real-time execution technique that allows explicit, precise timing control.
 
 ## Documentation


### PR DESCRIPTION
Gives the landing page a little more flair; see https://github.com/ssm-lang/ssm-runtime/tree/readme-badges

Right now these all point to the `dev` branch, but we will need to change these all to `main` once we merge `dev` into `main`.