### PR TITLE
Make unschedule part of drop

### DIFF
--- a/include/ssm-internal.h
+++ b/include/ssm-internal.h
@@ -84,6 +84,19 @@ void ssm_set_now(ssm_time_t next);
  */
 void ssm_update(ssm_sv_t *sv);
 
+/** @ingroup sv
+ *  @brief Unschedule any pending events on a variable.
+ *
+ *  Should be called before the variable is dropped.
+ *
+ *  Nothing happens if the variable does not have a pending event.
+ *
+ *  @platformonly
+ *
+ *  @param var  the variable.
+ */
+void ssm_unschedule(ssm_sv_t *var);
+
 /** @ingroup act
  *  @brief Run the system for the next scheduled instant.
  *

--- a/include/ssm.h
+++ b/include/ssm.h
@@ -631,18 +631,6 @@ void ssm_sensitize(ssm_sv_t *var, ssm_trigger_t *trig);
  */
 void ssm_desensitize(ssm_trigger_t *trig);
 
-/** @brief Unschedule any pending events on a variable.
- *
- *  Should be called before the variable is dropped.
- *
- *  Nothing happens if the variable does not have a pending event.
- *
- *  @todo move this to ssm-internal, since this will just be part of drop.
- *
- *  @param var  the variable.
- */
-void ssm_unschedule(ssm_sv_t *var);
-
 /** @} */
 
 /** @ingroup util

--- a/runtests.sh
+++ b/runtests.sh
@@ -19,21 +19,35 @@ BUILD_DIR=./build
 scriptname="$(basename "$0")"
 
 say () {
-  echo "[$scriptname]" "$@"
+  echo "[$scriptname]" "$@" >&2
 }
 
 run () {
   local exe="$BUILD_DIR/$1"
   shift
   echo "$exe" "$@"
+  set +e
   "$exe" "$@" 2>&1 | sed 's/^/# /'
+  local exit_code="$?"
+  set -e
+  if [ "$exit_code" -ne 0 ]; then
+    say "Non-zero exit code $exit_code encountered while running:" "$exe" "$@"
+    exit "$exit_code"
+  fi
 }
 
 vg () {
   local exe="$BUILD_DIR/$1"
   shift
   echo "$exe" "$@"
+  set +e
   valgrind "$exe" "$@" 2>&1 | sed 's/^/# /'
+  local exit_code="$?"
+  set -e
+  if [ "$exit_code" -ne 0 ]; then
+    say "Non-zero exit code $exit_code encountered with valgrind:" "$exe" "$@"
+    exit "$exit_code"
+  fi
 }
 
 make exes tests

--- a/src/ssm-mem.c
+++ b/src/ssm-mem.c
@@ -160,6 +160,7 @@ static inline void drop_children(struct ssm_mm *mm) {
     switch (mm->tag) {
     case SSM_SV_T: {
       ssm_sv_t *obj = container_of(mm, ssm_sv_t, mm);
+      ssm_unschedule(obj);
       if (ssm_on_heap(obj->value)) {
         ssm_drop(obj->value.heap_ptr);
       }

--- a/test/test-scheduler.c
+++ b/test/test-scheduler.c
@@ -36,11 +36,11 @@ void check_starts_initialized() {
 }
 
 void reset_all() {
-  ssm_reset();
-  for (int i = 0; i < NUM_VARIABLES; i++) {
+  for (int i = 0; i < NUM_VARIABLES; i++)
     ssm_drop(&ssm_to_sv(variables[i])->mm);
+  ssm_reset();
+  for (int i = 0; i < NUM_VARIABLES; i++)
     variables[i] = ssm_from_sv(ssm_new_sv(DUMMY_VALUE));
-  }
   check_starts_initialized();
 }
 
@@ -88,6 +88,7 @@ void event_queue_sort_string(const char *input, const char *expected) {
     char c = (char)event_queue[1]->later_time;
     printf("%c", c);
     SSM_ASSERT(c == *expected++);
+    event_queue[1]->later_time = SSM_NEVER;
     ssm_sv_t *to_insert = event_queue[event_queue_len--]; // get last
 
     if (event_queue_len) // Was this the last?
@@ -170,6 +171,7 @@ void event_queue_unschedule_string(const char *input, int n,
     char c = (char)event_queue[1]->later_time;
     printf("%c", c);
     SSM_ASSERT(c == *expected++);
+    event_queue[1]->later_time = SSM_NEVER;
     ssm_sv_t *to_insert = event_queue[event_queue_len--]; // get last
 
     if (event_queue_len) // Was this the last?
@@ -246,9 +248,10 @@ void act_queue_sort_tick(const char *input, const char *expected) {
   act_queue_consistency_check();
 
   SSM_ASSERT(*next_expected ==
-         0); // Did we end up at the end of the expected string?
+             0); // Did we end up at the end of the expected string?
 
-  SSM_ASSERT(act_queue_len == 0); // Should have emptied the activation record queue
+  SSM_ASSERT(act_queue_len ==
+             0); // Should have emptied the activation record queue
   printf("\n");
 
   // Make sure all the activation records were unscheduled


### PR DESCRIPTION
Addressing a todo I left for myself

I also uncovered a "bug" in the scheduler tests, in that it was not setting the `later_time` field to `SSM_NEVER`, violating variants that are otherwise upheld by the SSM library. This bug was only possible because we're doing whitebox testing, and was not previously a problem because the scheduler test was previously not very rigorous about resource management.

I also found a bug in my test-runner script, where it would terminate without any helpful error message if any test case or example threw a non-zero return code.