### PR TITLE
Fix SV initialization and configure valgrind tests to not mask memory errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ TEST_TGT := $(patsubst %.o, %, $(TEST_OBJ))
 COV_TGT := $(BUILD_DIR)/coverage.xml
 
 CC = cc
-CFLAGS = -g -I$(INC_DIR) -O -Wall -pedantic -std=c99
+CFLAGS += -g -I$(INC_DIR) -O -Wall -pedantic -std=c99
 TEST_CFLAGS = $(CFLAGS) -g -DSSM_DEBUG --coverage
 
 LD = cc

--- a/examples/fib.c
+++ b/examples/fib.c
@@ -91,9 +91,9 @@ void step_sum(struct ssm_act *act) {
     ssm_priority_t new_priority = act->priority;
     ssm_priority_t pinc = 1 << new_depth;
     ssm_dup(cont->r1);
+    ssm_dup(cont->r2);
     ssm_activate(ssm_enter_mywait(act, new_priority, new_depth, cont->r1));
     new_priority += pinc;
-    ssm_dup(cont->r2);
     ssm_activate(ssm_enter_mywait(act, new_priority, new_depth, cont->r2));
   }
     act->pc = 1;
@@ -128,34 +128,33 @@ void step_fib(struct ssm_act *act) {
   case 0:
     if (ssm_unmarshal(cont->n) < 2) {
       ssm_later(ssm_to_sv(cont->r), ssm_now() + SSM_SECOND, ssm_marshal(1));
+      break;
     } else {
       cont->r1 = ssm_new(SSM_BUILTIN, SSM_SV_T);
       ssm_sv_init(cont->r1, ssm_marshal(0));
+
       cont->r2 = ssm_new(SSM_BUILTIN, SSM_SV_T);
       ssm_sv_init(cont->r2, ssm_marshal(0));
+
+      ssm_dup(cont->r1);
+      ssm_dup(cont->r2);
+      ssm_dup(cont->r);
       ssm_depth_t new_depth = act->depth - 2; // 4 children
       ssm_priority_t new_priority = act->priority;
       ssm_priority_t pinc = 1 << new_depth;
-      ssm_dup(cont->r1);
       ssm_activate(ssm_enter_fib(act, new_priority, new_depth,
                                  ssm_marshal(ssm_unmarshal(cont->n) - 1),
                                  cont->r1));
       new_priority += pinc;
-      ssm_dup(cont->r2);
       ssm_activate(ssm_enter_fib(act, new_priority, new_depth,
                                  ssm_marshal(ssm_unmarshal(cont->n) - 2),
                                  cont->r2));
       new_priority += pinc;
-      ssm_dup(cont->r1);
-      ssm_dup(cont->r2);
-      ssm_dup(cont->r);
       ssm_activate(ssm_enter_sum(act, new_priority, new_depth, cont->r1,
                                  cont->r2, cont->r));
       act->pc = 1;
       return;
     case 1:;
-      ssm_drop(cont->r1);
-      ssm_drop(cont->r2);
     }
   }
   ssm_drop(cont->r);
@@ -175,4 +174,5 @@ void ssm_program_init(void) {
 
 void ssm_program_exit(void) {
   printf("%d\n", (int)ssm_unmarshal(ssm_deref(result)));
+  ssm_drop(result);
 }

--- a/include/ssm.h
+++ b/include/ssm.h
@@ -348,10 +348,12 @@ typedef struct ssm_sv {
  *  @param val  the initial value of the schedueld variable.
  */
 #define ssm_sv_init(sv, val)                                                   \
-  (*ssm_to_sv(sv) = (ssm_sv_t){.later_time = SSM_NEVER,                        \
-                               .last_updated = SSM_NEVER,                      \
-                               .triggers = NULL,                               \
-                               .value = val})
+  do {                                                                         \
+    ssm_to_sv(sv)->later_time = SSM_NEVER;                                     \
+    ssm_to_sv(sv)->last_updated = SSM_NEVER;                                   \
+    ssm_to_sv(sv)->triggers = NULL;                                            \
+    ssm_to_sv(sv)->value = val;                                                \
+  } while (0)
 
 /** @brief Instantaneous assignment to a scheduled variable.
  *
@@ -570,7 +572,6 @@ ssm_value_t ssm_new(uint8_t val_count, uint8_t tag);
  *  @param v  pointer to the #ssm_mm header of the heap item.
  */
 void ssm_dup_unsafe(ssm_value_t v);
-
 
 /** @brief Drop a reference to a heap item, and free it if necessary.
  *

--- a/runtests.sh
+++ b/runtests.sh
@@ -50,6 +50,7 @@ vg () {
   fi
 }
 
+make clean
 make exes tests
 
 if ! [ -d "$BUILD_DIR" ] ; then
@@ -91,6 +92,9 @@ else
   cat build/tests.diff
   exit 1
 fi
+
+make clean
+CFLAGS=-DSSM_DEBUG_NO_ALLOC make exes tests
 
 if command -v valgrind >/dev/null ; then
   rm -f build/examples.vg-out

--- a/src/ssm-mem.c
+++ b/src/ssm-mem.c
@@ -118,6 +118,9 @@ void ssm_mem_prealloc(size_t size, size_t num_pages) {
 }
 
 void *ssm_mem_alloc(size_t size) {
+#ifdef SSM_DEBUG_NO_ALLOC
+  return alloc_mem(size);
+#else
   size_t p = find_pool_size(size);
   if (p >= SSM_MEM_POOL_COUNT)
     return alloc_mem(size);
@@ -135,9 +138,13 @@ void *ssm_mem_alloc(size_t size) {
     pool->free_list_head = pool->free_list_head->free_list_next;
 
   return buf;
+#endif
 }
 
 void ssm_mem_free(void *m, size_t size) {
+#ifdef SSM_DEBUG_NO_ALLOC
+  free_mem(m, size);
+#else
   size_t pool = find_pool_size(size);
   if (pool >= SSM_MEM_POOL_COUNT) {
     free_mem(m, size);
@@ -147,6 +154,7 @@ void ssm_mem_free(void *m, size_t size) {
   block_t *new_head = m;
   new_head->free_list_next = mem_pools[pool].free_list_head;
   mem_pools[pool].free_list_head = new_head;
+#endif
 }
 
 /** @brief Recursively drop all children of a heap object.


### PR DESCRIPTION
There was a bug in the `ssm_sv_init()` macro that caused the memory management header to be "uninitialized", due to assigning a struct by value.

This PR also adds the option to compile the library without using the page-based pool allocator, so that valgrind is able to track fine-grained allocations and reveal memory errors (such as what was encountered here).