### PR TITLE
[RFC] Add offset field to mm header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ TEST_TGT := $(patsubst %.o, %, $(TEST_OBJ))
 COV_TGT := $(BUILD_DIR)/coverage.xml
 
 CC = cc
-CFLAGS = -g -I$(INC_DIR) -O -Wall -pedantic -std=c99
+CFLAGS += -g -I$(INC_DIR) -O -Wall -pedantic -std=c99
 TEST_CFLAGS = $(CFLAGS) -g -DSSM_DEBUG --coverage
 
 LD = cc

--- a/examples/clock.c
+++ b/examples/clock.c
@@ -60,7 +60,7 @@ void step_second_clock(struct ssm_act *act) {
   act_second_clock_t *cont = container_of(act, act_second_clock_t, act);
   switch (act->pc) {
   case 0:
-    cont->timer = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->timer = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->timer, EVENT_VALUE);
     for (;;) {
       ssm_assign(ssm_to_sv(cont->second_event), act->priority, EVENT_VALUE);
@@ -96,7 +96,7 @@ void step_report_seconds(struct ssm_act *act) {
 
   switch (act->pc) {
   case 0:
-    cont->seconds = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->seconds = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->seconds, ssm_marshal(0));
     for (;;) {
       cont->trigger1.act = act;
@@ -132,7 +132,7 @@ void step_main(struct ssm_act *act) {
 
   switch (act->pc) {
   case 0: {
-    cont->second = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->second = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->second, EVENT_VALUE);
     ssm_depth_t new_depth = act->depth - 1;
     ssm_priority_t new_priority = act->priority;

--- a/examples/counter.c
+++ b/examples/counter.c
@@ -302,15 +302,15 @@ void step_main(struct ssm_act *act) {
 
   switch (act->pc) {
   case 0:
-    cont->clk = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->clk = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->clk, ssm_marshal(0));
-    cont->q1 = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->q1 = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->q1, ssm_marshal(0));
-    cont->q2 = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->q2 = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->q2, ssm_marshal(0));
-    cont->d1 = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->d1 = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->d1, ssm_marshal(0));
-    cont->d2 = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->d2 = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->d2, ssm_marshal(0));
 
     ssm_depth_t new_depth;

--- a/examples/fib.c
+++ b/examples/fib.c
@@ -91,9 +91,9 @@ void step_sum(struct ssm_act *act) {
     ssm_priority_t new_priority = act->priority;
     ssm_priority_t pinc = 1 << new_depth;
     ssm_dup(cont->r1);
+    ssm_dup(cont->r2);
     ssm_activate(ssm_enter_mywait(act, new_priority, new_depth, cont->r1));
     new_priority += pinc;
-    ssm_dup(cont->r2);
     ssm_activate(ssm_enter_mywait(act, new_priority, new_depth, cont->r2));
   }
     act->pc = 1;
@@ -128,34 +128,33 @@ void step_fib(struct ssm_act *act) {
   case 0:
     if (ssm_unmarshal(cont->n) < 2) {
       ssm_later(ssm_to_sv(cont->r), ssm_now() + SSM_SECOND, ssm_marshal(1));
+      break;
     } else {
       cont->r1 = ssm_new(SSM_BUILTIN, SSM_SV_T);
       ssm_sv_init(cont->r1, ssm_marshal(0));
+
       cont->r2 = ssm_new(SSM_BUILTIN, SSM_SV_T);
       ssm_sv_init(cont->r2, ssm_marshal(0));
+
+      ssm_dup(cont->r1);
+      ssm_dup(cont->r2);
+      ssm_dup(cont->r);
       ssm_depth_t new_depth = act->depth - 2; // 4 children
       ssm_priority_t new_priority = act->priority;
       ssm_priority_t pinc = 1 << new_depth;
-      ssm_dup(cont->r1);
       ssm_activate(ssm_enter_fib(act, new_priority, new_depth,
                                  ssm_marshal(ssm_unmarshal(cont->n) - 1),
                                  cont->r1));
       new_priority += pinc;
-      ssm_dup(cont->r2);
       ssm_activate(ssm_enter_fib(act, new_priority, new_depth,
                                  ssm_marshal(ssm_unmarshal(cont->n) - 2),
                                  cont->r2));
       new_priority += pinc;
-      ssm_dup(cont->r1);
-      ssm_dup(cont->r2);
-      ssm_dup(cont->r);
       ssm_activate(ssm_enter_sum(act, new_priority, new_depth, cont->r1,
                                  cont->r2, cont->r));
       act->pc = 1;
       return;
     case 1:;
-      ssm_drop(cont->r1);
-      ssm_drop(cont->r2);
     }
   }
   ssm_drop(cont->r);
@@ -175,4 +174,5 @@ void ssm_program_init(void) {
 
 void ssm_program_exit(void) {
   printf("%d\n", (int)ssm_unmarshal(ssm_deref(result)));
+  ssm_drop(result);
 }

--- a/examples/fib.c
+++ b/examples/fib.c
@@ -129,9 +129,9 @@ void step_fib(struct ssm_act *act) {
     if (ssm_unmarshal(cont->n) < 2) {
       ssm_later(ssm_to_sv(cont->r), ssm_now() + SSM_SECOND, ssm_marshal(1));
     } else {
-      cont->r1 = ssm_new(SSM_BUILTIN, SSM_SV_T);
+      cont->r1 = ssm_new_builtin(SSM_SV_T);
       ssm_sv_init(cont->r1, ssm_marshal(0));
-      cont->r2 = ssm_new(SSM_BUILTIN, SSM_SV_T);
+      cont->r2 = ssm_new_builtin(SSM_SV_T);
       ssm_sv_init(cont->r2, ssm_marshal(0));
       ssm_depth_t new_depth = act->depth - 2; // 4 children
       ssm_priority_t new_priority = act->priority;
@@ -164,7 +164,7 @@ void step_fib(struct ssm_act *act) {
 
 ssm_u32_t result;
 void ssm_program_init(void) {
-  result = ssm_new(SSM_BUILTIN, SSM_SV_T);
+  result = ssm_new_builtin(SSM_SV_T);
   ssm_sv_init(result, ssm_marshal(0xdeadbeef));
 
   int n = ssm_init_args && ssm_init_args[0] ? atoi(ssm_init_args[0]) : 3;

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -110,7 +110,7 @@ void step_main(ssm_act_t *act) {
   main_act_t *cont = container_of(act, main_act_t, act);
   switch (act->pc) {
   case 0:
-    cont->stdout = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->stdout = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->stdout, ssm_marshal(0));
     ssm_depth_t new_depth = act->depth - 1;
     ssm_priority_t new_priority = act->priority;

--- a/examples/list.c
+++ b/examples/list.c
@@ -29,11 +29,8 @@ should print:
   1::2::3::[]
  */
 
-enum List { Nil = 0, Cons, List_variants };
-uint8_t List_size[List_variants] = {
-    [Nil] = 0,
-    [Cons] = 2,
-};
+enum { Nil = 0, Cons };
+enum { List_val_count = 2 };
 
 ssm_value_t list;
 
@@ -73,8 +70,8 @@ void step_map_inc(ssm_act_t *act) {
     *cont->__ret = ssm_marshal(Nil);
     break;
   match_Cons_0:;
-    ssm_value_t __i = ssm_to_obj(cont->l)[0];
-    ssm_value_t __l = ssm_to_obj(cont->l)[1];
+    ssm_value_t __i = ssm_adt_val(cont->l, 0);
+    ssm_value_t __l = ssm_adt_val(cont->l, 1);
     ssm_dup(__l);
 
     ssm_drop(cont->l);
@@ -86,9 +83,9 @@ void step_map_inc(ssm_act_t *act) {
     act->pc = 1;
     return;
   case 1:;
-    *cont->__ret = ssm_new(List_size[Cons], Cons);
-    ssm_to_obj(*cont->__ret)[0] = cont->__tmp0;
-    ssm_to_obj(*cont->__ret)[1] = cont->__tmp1;
+    *cont->__ret = ssm_new(Cons, List_val_count);
+    ssm_adt_val(*cont->__ret, 0) = cont->__tmp0;
+    ssm_adt_val(*cont->__ret, 1) = cont->__tmp1;
     break;
   }
   ssm_leave(&cont->act, sizeof(act_map_inc_t));
@@ -128,8 +125,8 @@ void step_print_list(ssm_act_t *act) {
     printf("[]\r\n");
     break;
   match_Cons_0:;
-    ssm_value_t __i = ssm_to_obj(cont->l)[0];
-    ssm_value_t __l = ssm_to_obj(cont->l)[1];
+    ssm_value_t __i = ssm_adt_val(cont->l, 0);
+    ssm_value_t __l = ssm_adt_val(cont->l, 1);
     ssm_dup(__l);
 
     ssm_drop(cont->l);
@@ -194,9 +191,9 @@ void ssm_program_init(void) {
   list = v;
   int i = ssm_init_args && ssm_init_args[0] ? atoi(ssm_init_args[0]) : 3;
   for (; i >= 1; i--) {
-    v = ssm_new(List_size[Cons], Cons);
-    ssm_to_obj(v)[0] = ssm_marshal(i);
-    ssm_to_obj(v)[1] = list;
+    v = ssm_new(Cons, List_val_count);
+    ssm_adt_val(v, 0) = ssm_marshal(i);
+    ssm_adt_val(v, 1) = list;
     list = v;
   }
   ssm_dup(list); // main captures reference to global by closure

--- a/examples/onetwo.c
+++ b/examples/onetwo.c
@@ -109,7 +109,7 @@ void step_main(struct ssm_act *act) {
   act_main_t *cont = container_of(act, act_main_t, act);
   switch (act->pc) {
   case 0:
-    cont->a = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    cont->a = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(cont->a, ssm_marshal(0));
 
     ssm_later(ssm_to_sv(cont->a), ssm_now() + 100, ssm_marshal(10));

--- a/include/ssm.h
+++ b/include/ssm.h
@@ -148,7 +148,8 @@ typedef union {
  */
 #define ssm_on_heap(v) (((v).packed_val & 0x1) == 0)
 
-#define SSM_NIL (ssm_value_t) { .packed_val = 0xffffffff }
+#define SSM_NIL                                                                \
+  (ssm_value_t) { .packed_val = 0xffffffff }
 
 /** @} */
 
@@ -495,7 +496,7 @@ enum ssm_builtin {
  */
 #define SSM_BUILTIN_VAL_OFFSET(tg)                                             \
   ((size_t[]){                                                                 \
-      [SSM_TIME_T - SSM_BUILTIN_BASE] = offsetof(struct ssm_time, time),       \
+      [SSM_TIME_T - SSM_BUILTIN_BASE] = sizeof(struct ssm_time),               \
       [SSM_SV_T - SSM_BUILTIN_BASE] = offsetof(ssm_sv_t, value),               \
   }[(tg)-SSM_BUILTIN_BASE])
 

--- a/include/ssm.h
+++ b/include/ssm.h
@@ -348,10 +348,12 @@ typedef struct ssm_sv {
  *  @param val  the initial value of the schedueld variable.
  */
 #define ssm_sv_init(sv, val)                                                   \
-  (*ssm_to_sv(sv) = (ssm_sv_t){.later_time = SSM_NEVER,                        \
-                               .last_updated = SSM_NEVER,                      \
-                               .triggers = NULL,                               \
-                               .value = val})
+  do {                                                                         \
+    ssm_to_sv(sv)->later_time = SSM_NEVER;                                     \
+    ssm_to_sv(sv)->last_updated = SSM_NEVER;                                   \
+    ssm_to_sv(sv)->triggers = NULL;                                            \
+    ssm_to_sv(sv)->value = val;                                                \
+  } while (0)
 
 /** @brief Instantaneous assignment to a scheduled variable.
  *
@@ -570,7 +572,6 @@ ssm_value_t ssm_new(uint8_t val_count, uint8_t tag);
  *  @param v  pointer to the #ssm_mm header of the heap item.
  */
 void ssm_dup_unsafe(ssm_value_t v);
-
 
 /** @brief Drop a reference to a heap item, and free it if necessary.
  *

--- a/runtests.sh
+++ b/runtests.sh
@@ -50,6 +50,7 @@ vg () {
   fi
 }
 
+make clean
 make exes tests
 
 if ! [ -d "$BUILD_DIR" ] ; then
@@ -91,6 +92,9 @@ else
   cat build/tests.diff
   exit 1
 fi
+
+make clean
+CFLAGS=-DSSM_DEBUG_NO_ALLOC make exes tests
 
 if command -v valgrind >/dev/null ; then
   rm -f build/examples.vg-out

--- a/src/ssm-mem.c
+++ b/src/ssm-mem.c
@@ -118,6 +118,9 @@ void ssm_mem_prealloc(size_t size, size_t num_pages) {
 }
 
 void *ssm_mem_alloc(size_t size) {
+#ifdef SSM_DEBUG_NO_ALLOC
+  return alloc_mem(size);
+#else
   size_t p = find_pool_size(size);
   if (p >= SSM_MEM_POOL_COUNT)
     return alloc_mem(size);
@@ -135,9 +138,13 @@ void *ssm_mem_alloc(size_t size) {
     pool->free_list_head = pool->free_list_head->free_list_next;
 
   return buf;
+#endif
 }
 
 void ssm_mem_free(void *m, size_t size) {
+#ifdef SSM_DEBUG_NO_ALLOC
+  free_mem(m, size);
+#else
   size_t pool = find_pool_size(size);
   if (pool >= SSM_MEM_POOL_COUNT) {
     free_mem(m, size);
@@ -147,6 +154,7 @@ void ssm_mem_free(void *m, size_t size) {
   block_t *new_head = m;
   new_head->free_list_next = mem_pools[pool].free_list_head;
   mem_pools[pool].free_list_head = new_head;
+#endif
 }
 
 /** @brief Recursively drop all children of a heap object.

--- a/src/ssm-mem.c
+++ b/src/ssm-mem.c
@@ -166,7 +166,7 @@ static inline void drop_children(ssm_value_t v) {
   }
 
   for (size_t i = 0; i < v.heap_ptr->val_count; i++) {
-    ssm_value_t val = ssm_mm_val(v.heap_ptr, v.heap_ptr->val_offset, i);
+    ssm_value_t val = *SSM_OBJ_VAL(v.heap_ptr, v.heap_ptr->val_offset, i);
     if (ssm_on_heap(val))
       ssm_drop(val);
   }

--- a/test/test-scheduler.c
+++ b/test/test-scheduler.c
@@ -40,7 +40,7 @@ void reset_all() {
     ssm_drop(variables[i]);
   ssm_reset();
   for (int i = 0; i < NUM_VARIABLES; i++) {
-    variables[i] = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    variables[i] = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(variables[i], DUMMY_VALUE);
   }
   check_starts_initialized();
@@ -439,7 +439,7 @@ int main(void) {
   ssm_mem_init(alloc_page, alloc_mem, free_mem);
 
   for (int i = 0; i < NUM_VARIABLES; i++) {
-    variables[i] = ssm_new(SSM_BUILTIN, SSM_SV_T);
+    variables[i] = ssm_new_builtin(SSM_SV_T);
     ssm_sv_init(variables[i], DUMMY_VALUE);
   }
 


### PR DESCRIPTION
I've been thinking about our memory management header, and how best to ensure its flexibility for future features like closures, arrays, and eventually arbitrary-sized ADTs (with more than 256 possible tags). I think I've come up with a solution, implemented in this PR.

My proposal is to add a `val_offset` field to each memory management header, which indicates the byte offset from the beginning of the heap payload at which a continguous array of values may be found:

```c
struct ssm_mm {
  uint8_t ref_count;
  uint8_t tag;
  uint8_t val_count;
  uint8_t val_offset;
};
```

I have yet to add this to code documentation, but the general shape of each managed memory chunk will look like this:

```
+-------------------------+ ---
| struct ssm_mm mm;       |  |
+-------------------------+  |
| ////////padding//////// |  | val_offset bytes
|    unmanaged payload    |  |
| ////////padding//////// |  |
+-------------------------+ -+-
| ssm_value_t payload[0]; |  |
| ssm_value_t payload[1]; |  | val_count * ssm_value_t
| ...                     |  |
| ...                     |  |
+-------------------------+ ---
```

The padding may differ depending on the platform and the contents of the managed payload, but `val_offset` is agnostic to that.

Then each memory-managed construct can be expressed as a combination of `val_offset` and `val_count`: ADTs/tuples are the special case where there is no unmanaged payload, and `val_offset` is exactly the size of the memory management header; heap-allocated times have a `val_count` of zero and a `val_offset` equal to the size of `struct ssm_time` (its representation on the heap); `ssm_sv_t` have `val_count` of 2 (one for `value` and one for `later_value`) and `val_offset` of `offsetof(ssm_sv_t, value)`.

This flexibility allows us to encode data of up to 224B of data in the unmanaged payload that can represent (effectively) arbitrarily large tag values, array sizes, pointers, and other essentially binary data.

Another change from before is that we are no longer type punning the mm header data. Previously, we designated a rule that if `val_count` was 0, then the `tag` would be used to indicate one of a handful fo built-in types. Now, we will just encode those builtin types using the `tag` field with values beyond 128; user-defined tags are limited to 128. In the future, support for larger tags can be added by creating an `SSM_HUGE_TAG` builtin type where the tag value is stored as a 64-bit integer in the unmanaged payload.

This has no impact on the actual size of the mm header, since we were previously only using 3 out of 4 available bytes. This should result in no performance impact, and may even theoretically improve performance, since instead of looking up the value offsets, it can be directly interpreted from the `val_offset` field of the mm header.

I still need to:

- [ ] update the code documentation for the new changes (currently causing CI to fail)
- [ ] perhaps write some test cases for the memory layout