### PR TITLE
Add automatic reference counting to SV methods

### DIFF
--- a/examples/clock.c
+++ b/examples/clock.c
@@ -65,7 +65,7 @@ void step_second_clock(struct ssm_act *act) {
       ssm_assign(cont->second_event, act->priority, EVENT_VALUE);
       ssm_later(cont->timer, ssm_now() + SSM_SECOND, EVENT_VALUE);
       cont->trigger1.act = act;
-      ssm_sensitize(ssm_to_sv(cont->timer), &cont->trigger1);
+      ssm_sensitize(cont->timer, &cont->trigger1);
       act->pc = 1;
       return;
     case 1:
@@ -98,7 +98,7 @@ void step_report_seconds(struct ssm_act *act) {
     cont->seconds = ssm_new_sv(ssm_marshal(0));
     for (;;) {
       cont->trigger1.act = act;
-      ssm_sensitize(ssm_to_sv(cont->second_event), &cont->trigger1);
+      ssm_sensitize(cont->second_event, &cont->trigger1);
       act->pc = 1;
       return;
     case 1:

--- a/examples/clock.c
+++ b/examples/clock.c
@@ -62,8 +62,8 @@ void step_second_clock(struct ssm_act *act) {
   case 0:
     cont->timer = ssm_new_sv(EVENT_VALUE);
     for (;;) {
-      ssm_assign(ssm_to_sv(cont->second_event), act->priority, EVENT_VALUE);
-      ssm_later(ssm_to_sv(cont->timer), ssm_now() + SSM_SECOND, EVENT_VALUE);
+      ssm_assign(cont->second_event, act->priority, EVENT_VALUE);
+      ssm_later(cont->timer, ssm_now() + SSM_SECOND, EVENT_VALUE);
       cont->trigger1.act = act;
       ssm_sensitize(ssm_to_sv(cont->timer), &cont->trigger1);
       act->pc = 1;
@@ -103,7 +103,7 @@ void step_report_seconds(struct ssm_act *act) {
       return;
     case 1:
       ssm_desensitize(&cont->trigger1);
-      ssm_assign(ssm_to_sv(cont->seconds), act->priority,
+      ssm_assign(cont->seconds, act->priority,
                  ssm_marshal(ssm_unmarshal(ssm_deref(cont->seconds)) + 1));
 
       printf("%d\n", (int)ssm_unmarshal(ssm_deref(cont->seconds)));

--- a/examples/counter.c
+++ b/examples/counter.c
@@ -111,13 +111,13 @@ void step_clock(struct ssm_act *act) {
   case 0:
     for (;;) {
       ssm_later(cont->clk, ssm_now() + (2 * SSM_SECOND), ssm_marshal(1));
-      ssm_sensitize(ssm_to_sv(cont->clk), &cont->trigger1);
+      ssm_sensitize(cont->clk, &cont->trigger1);
       act->pc = 1;
       return;
     case 1:
       ssm_desensitize(&cont->trigger1);
       ssm_later(cont->clk, ssm_now() + (2 * SSM_SECOND), ssm_marshal(0));
-      ssm_sensitize(ssm_to_sv(cont->clk), &cont->trigger1);
+      ssm_sensitize(cont->clk, &cont->trigger1);
       act->pc = 2;
       return;
     case 2:
@@ -156,7 +156,7 @@ void step_dff1(struct ssm_act *act) {
     for (;;) {
       if (ssm_unmarshal(ssm_deref(cont->clk)))
         ssm_assign(cont->q1, act->priority, ssm_deref(cont->d1));
-      ssm_sensitize(ssm_to_sv(cont->clk), &cont->trigger1);
+      ssm_sensitize(cont->clk, &cont->trigger1);
       act->pc = 1;
       return;
     case 1:
@@ -197,7 +197,7 @@ void step_dff2(struct ssm_act *act) {
     for (;;) {
       if ((int)ssm_unmarshal(ssm_deref(cont->clk)))
         ssm_assign(cont->q2, act->priority, ssm_deref(cont->d2));
-      ssm_sensitize(ssm_to_sv(cont->clk), &cont->trigger1);
+      ssm_sensitize(cont->clk, &cont->trigger1);
       act->pc = 1;
       return;
     case 1:
@@ -230,7 +230,7 @@ void step_incr(struct ssm_act *act) {
     for (;;) {
       ssm_assign(cont->d2, act->priority,
                  ssm_marshal(ssm_unmarshal(ssm_deref(cont->q2)) + 1));
-      ssm_sensitize(ssm_to_sv(cont->q2), &cont->trigger1);
+      ssm_sensitize(cont->q2, &cont->trigger1);
       act->pc = 1;
       return;
     case 1:
@@ -269,8 +269,8 @@ void step_adder(struct ssm_act *act) {
       ssm_assign(cont->d1, act->priority,
                  ssm_marshal(ssm_unmarshal(ssm_deref(cont->q1)) +
                              ssm_unmarshal(ssm_deref(cont->d2))));
-      ssm_sensitize(ssm_to_sv(cont->q2), &cont->trigger1);
-      ssm_sensitize(ssm_to_sv(cont->d2), &cont->trigger2);
+      ssm_sensitize(cont->q2, &cont->trigger1);
+      ssm_sensitize(cont->d2, &cont->trigger2);
       act->pc = 1;
       return;
     case 1:

--- a/examples/counter.c
+++ b/examples/counter.c
@@ -110,15 +110,13 @@ void step_clock(struct ssm_act *act) {
   switch (act->pc) {
   case 0:
     for (;;) {
-      ssm_later(ssm_to_sv(cont->clk), ssm_now() + (2 * SSM_SECOND),
-                ssm_marshal(1));
+      ssm_later(cont->clk, ssm_now() + (2 * SSM_SECOND), ssm_marshal(1));
       ssm_sensitize(ssm_to_sv(cont->clk), &cont->trigger1);
       act->pc = 1;
       return;
     case 1:
       ssm_desensitize(&cont->trigger1);
-      ssm_later(ssm_to_sv(cont->clk), ssm_now() + (2 * SSM_SECOND),
-                ssm_marshal(0));
+      ssm_later(cont->clk, ssm_now() + (2 * SSM_SECOND), ssm_marshal(0));
       ssm_sensitize(ssm_to_sv(cont->clk), &cont->trigger1);
       act->pc = 2;
       return;
@@ -157,7 +155,7 @@ void step_dff1(struct ssm_act *act) {
   case 0:
     for (;;) {
       if (ssm_unmarshal(ssm_deref(cont->clk)))
-        ssm_assign(ssm_to_sv(cont->q1), act->priority, ssm_deref(cont->d1));
+        ssm_assign(cont->q1, act->priority, ssm_deref(cont->d1));
       ssm_sensitize(ssm_to_sv(cont->clk), &cont->trigger1);
       act->pc = 1;
       return;
@@ -198,7 +196,7 @@ void step_dff2(struct ssm_act *act) {
   case 0:
     for (;;) {
       if ((int)ssm_unmarshal(ssm_deref(cont->clk)))
-        ssm_assign(ssm_to_sv(cont->q2), act->priority, ssm_deref(cont->d2));
+        ssm_assign(cont->q2, act->priority, ssm_deref(cont->d2));
       ssm_sensitize(ssm_to_sv(cont->clk), &cont->trigger1);
       act->pc = 1;
       return;
@@ -230,7 +228,7 @@ void step_incr(struct ssm_act *act) {
   switch (act->pc) {
   case 0:
     for (;;) {
-      ssm_assign(ssm_to_sv(cont->d2), act->priority,
+      ssm_assign(cont->d2, act->priority,
                  ssm_marshal(ssm_unmarshal(ssm_deref(cont->q2)) + 1));
       ssm_sensitize(ssm_to_sv(cont->q2), &cont->trigger1);
       act->pc = 1;
@@ -268,7 +266,7 @@ void step_adder(struct ssm_act *act) {
   switch (act->pc) {
   case 0:
     for (;;) {
-      ssm_assign(ssm_to_sv(cont->d1), act->priority,
+      ssm_assign(cont->d1, act->priority,
                  ssm_marshal(ssm_unmarshal(ssm_deref(cont->q1)) +
                              ssm_unmarshal(ssm_deref(cont->d2))));
       ssm_sensitize(ssm_to_sv(cont->q2), &cont->trigger1);

--- a/examples/fib.c
+++ b/examples/fib.c
@@ -99,7 +99,7 @@ void step_sum(struct ssm_act *act) {
     act->pc = 1;
     return;
   case 1:
-    ssm_later(ssm_to_sv(cont->r), ssm_now() + SSM_SECOND,
+    ssm_later(cont->r, ssm_now() + SSM_SECOND,
               ssm_marshal(ssm_unmarshal(ssm_deref(cont->r1)) +
                           ssm_unmarshal(ssm_deref(cont->r2))));
     break;
@@ -127,7 +127,7 @@ void step_fib(struct ssm_act *act) {
   switch (act->pc) {
   case 0:
     if (ssm_unmarshal(cont->n) < 2) {
-      ssm_later(ssm_to_sv(cont->r), ssm_now() + SSM_SECOND, ssm_marshal(1));
+      ssm_later(cont->r, ssm_now() + SSM_SECOND, ssm_marshal(1));
       break;
     } else {
       cont->r1 = ssm_new_sv(ssm_marshal(0));

--- a/examples/fib.c
+++ b/examples/fib.c
@@ -58,7 +58,7 @@ void step_mywait(struct ssm_act *act) {
   switch (act->pc) {
   case 0:
     cont->trigger1.act = act;
-    ssm_sensitize(ssm_to_sv(cont->r), &cont->trigger1);
+    ssm_sensitize(cont->r, &cont->trigger1);
     act->pc = 1;
     return;
   case 1:

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -38,7 +38,7 @@ void step_hello(ssm_act_t *act) {
 
 #define print_yield(p, c)                                                      \
   ssm_later(cont->stdout, ssm_now() + 10, ssm_marshal(c));                     \
-  ssm_sensitize(ssm_to_sv(cont->stdout), &cont->trigger1);                     \
+  ssm_sensitize(cont->stdout, &cont->trigger1);                     \
   act->pc = p;                                                                 \
   return;                                                                      \
   case p:                                                                      \
@@ -80,7 +80,7 @@ void step_print(ssm_act_t *act) {
   switch (act->pc) {
   case 0:
     for (;;) {
-      ssm_sensitize(ssm_to_sv(cont->stdout), &cont->trigger1);
+      ssm_sensitize(cont->stdout, &cont->trigger1);
       act->pc = 1;
       return;
     case 1:

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -37,7 +37,7 @@ void step_hello(ssm_act_t *act) {
   case 0:
 
 #define print_yield(p, c)                                                      \
-  ssm_later(ssm_to_sv(cont->stdout), ssm_now() + 10, ssm_marshal(c));          \
+  ssm_later(cont->stdout, ssm_now() + 10, ssm_marshal(c));                     \
   ssm_sensitize(ssm_to_sv(cont->stdout), &cont->trigger1);                     \
   act->pc = p;                                                                 \
   return;                                                                      \

--- a/examples/onetwo.c
+++ b/examples/onetwo.c
@@ -54,7 +54,7 @@ void step_one(struct ssm_act *act) {
 
   switch (act->pc) {
   case 0:
-    ssm_sensitize(ssm_to_sv(cont->a), &cont->trigger1);
+    ssm_sensitize(cont->a, &cont->trigger1);
     act->pc = 1;
     return;
   case 1:
@@ -83,7 +83,7 @@ void step_two(struct ssm_act *act) {
   act_two_t *cont = container_of(act, act_two_t, act);
   switch (act->pc) {
   case 0:
-    ssm_sensitize(ssm_to_sv(cont->a), &cont->trigger1);
+    ssm_sensitize(cont->a, &cont->trigger1);
     act->pc = 1;
     return;
   case 1:

--- a/examples/onetwo.c
+++ b/examples/onetwo.c
@@ -59,7 +59,7 @@ void step_one(struct ssm_act *act) {
     return;
   case 1:
     ssm_desensitize(&cont->trigger1);
-    ssm_assign(ssm_to_sv(cont->a), act->priority,
+    ssm_assign(cont->a, act->priority,
                ssm_marshal(ssm_unmarshal(ssm_deref(cont->a)) + 1));
   }
   ssm_drop(cont->a);
@@ -88,7 +88,7 @@ void step_two(struct ssm_act *act) {
     return;
   case 1:
     ssm_desensitize(&cont->trigger1);
-    ssm_assign(ssm_to_sv(cont->a), act->priority,
+    ssm_assign(cont->a, act->priority,
                ssm_marshal(ssm_unmarshal(ssm_deref(cont->a)) * 2));
   }
   ssm_drop(cont->a);
@@ -111,7 +111,7 @@ void step_main(struct ssm_act *act) {
   case 0:
     cont->a = ssm_new_sv(ssm_marshal(0));
 
-    ssm_later(ssm_to_sv(cont->a), ssm_now() + 100, ssm_marshal(10));
+    ssm_later(cont->a, ssm_now() + 100, ssm_marshal(10));
     {
       ssm_depth_t new_depth = act->depth - 1; // 2 children
       ssm_priority_t new_priority = act->priority;

--- a/src/ssm-scheduler.c
+++ b/src/ssm-scheduler.c
@@ -298,22 +298,22 @@ void ssm_activate(ssm_act_t *act) {
   act_queue_percolate_up(hole, act);
 }
 
-void ssm_assign_unsafe(ssm_sv_t *var, ssm_priority_t prio, ssm_value_t value) {
-  var->value = value;
+void ssm_sv_assign_unsafe(ssm_sv_t *var, ssm_priority_t prio, ssm_value_t val) {
+  var->value = val;
   var->last_updated = now;
   for (ssm_trigger_t *trig = var->triggers; trig; trig = trig->next)
     if (trig->act->priority > prio)
       ssm_activate(trig->act);
 }
 
-void ssm_later_unsafe(ssm_sv_t *var, ssm_time_t later, ssm_value_t value) {
-  if (later < now)
+void ssm_sv_later_unsafe(ssm_sv_t *var, ssm_time_t when, ssm_value_t val) {
+  if (when < now)
     // later must be in the future
     SSM_THROW(SSM_INVALID_TIME);
 
   if (var->later_time == SSM_NEVER) {
     // Variable does not have a pending event
-    var->later_time = later;
+    var->later_time = when;
 
     // Add it to the queue
     q_idx_t hole = ++event_queue_len;
@@ -323,43 +323,43 @@ void ssm_later_unsafe(ssm_sv_t *var, ssm_time_t later, ssm_value_t value) {
 
   } else {
     // Variable has a pending event
-    var->later_time = later;
+    var->later_time = when;
 
     // Drop the old pending value
     ssm_drop(var->later_value);
 
     // Reposition the event in the queue as appropriate
     q_idx_t hole = find_queued_event(var);
-    if (hole == SSM_QUEUE_HEAD || event_queue[hole >> 1]->later_time < later)
+    if (hole == SSM_QUEUE_HEAD || event_queue[hole >> 1]->later_time < when)
       event_queue_percolate_down(hole, var);
     else
       event_queue_percolate_up(hole, var);
   }
-  var->later_value = value;
+  var->later_value = val;
 }
 
-void ssm_sensitize(ssm_sv_t *var, ssm_trigger_t *trigger) {
+void ssm_sv_sensitize(ssm_sv_t *var, ssm_trigger_t *trig) {
   // Point us to the first element
-  trigger->next = var->triggers;
+  trig->next = var->triggers;
 
   if (var->triggers)
     // Make first element point to us
-    var->triggers->prev_ptr = &trigger->next;
+    var->triggers->prev_ptr = &trig->next;
 
   // Insert us at the beginning
-  var->triggers = trigger;
+  var->triggers = trig;
 
   // Our previous is the variable
-  trigger->prev_ptr = &var->triggers;
+  trig->prev_ptr = &var->triggers;
 }
 
-void ssm_desensitize(ssm_trigger_t *trigger) {
+void ssm_sv_desensitize(ssm_trigger_t *trig) {
   // Tell predecessor to skip us
-  *trigger->prev_ptr = trigger->next;
+  *trig->prev_ptr = trig->next;
 
-  if (trigger->next)
+  if (trig->next)
     // Tell successor its predecessor is our predecessor
-    trigger->next->prev_ptr = trigger->prev_ptr;
+    trig->next->prev_ptr = trig->prev_ptr;
 }
 
 void ssm_unschedule(ssm_sv_t *var) {

--- a/test/test-scheduler.c
+++ b/test/test-scheduler.c
@@ -49,7 +49,7 @@ void event_queue_basic() {
   reset_all();
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
   SSM_ASSERT(ssm_to_sv(variables[0])->last_updated != ssm_now());
-  ssm_later(ssm_to_sv(variables[0]), 1, DUMMY_VALUE);
+  ssm_later(variables[0], 1, DUMMY_VALUE);
   SSM_ASSERT(event_queue_len == 1);
   SSM_ASSERT(ssm_next_event_time() == 1);
   event_queue_consistency_check();
@@ -80,7 +80,7 @@ void event_queue_sort_string(const char *input, const char *expected) {
   SSM_ASSERT(event_queue_len == 0);
   ssm_value_t *var = variables;
   for (const char *cp = input; *cp; ++cp, ++var) {
-    ssm_later(ssm_to_sv(*var), (ssm_time_t)*cp, DUMMY_VALUE);
+    ssm_later(*var, (ssm_time_t)*cp, DUMMY_VALUE);
     event_queue_consistency_check();
   }
 
@@ -110,7 +110,7 @@ void event_queue_reschedule_string(const char *input, const char *expected) {
   ssm_value_t *var = variables;
 
   for (const char *cp = input; *cp; ++cp, ++var) {
-    ssm_later(ssm_to_sv(*var), (ssm_time_t)*cp, DUMMY_VALUE);
+    ssm_later(*var, (ssm_time_t)*cp, DUMMY_VALUE);
     event_queue_consistency_check();
   }
 
@@ -122,9 +122,9 @@ void event_queue_reschedule_string(const char *input, const char *expected) {
   for (const char *cp = input; *cp; ++cp, ++var) {
     if (*cp != ' ') {
       if (*cp > 'Z')
-        ssm_later(ssm_to_sv(*var), (ssm_time_t)*cp + 'A' - 'a', DUMMY_VALUE);
+        ssm_later(*var, (ssm_time_t)*cp + 'A' - 'a', DUMMY_VALUE);
       else
-        ssm_later(ssm_to_sv(*var), (ssm_time_t)*cp + 'a' - 'A', DUMMY_VALUE);
+        ssm_later(*var, (ssm_time_t)*cp + 'a' - 'A', DUMMY_VALUE);
     }
     event_queue_consistency_check();
   }
@@ -149,7 +149,7 @@ void event_queue_unschedule_string(const char *input, int n,
   reset_all();
   ssm_value_t *var = variables;
   for (const char *cp = input; *cp; ++cp, ++var) {
-    ssm_later(ssm_to_sv(*var), (ssm_time_t)*cp, DUMMY_VALUE);
+    ssm_later(*var, (ssm_time_t)*cp, DUMMY_VALUE);
     event_queue_consistency_check();
   }
 
@@ -291,7 +291,7 @@ void trigger_basic() {
   ssm_sensitize(ssm_to_sv(variables[0]), &triggers[1]);
   ssm_sensitize(ssm_to_sv(variables[0]), &triggers[2]);
 
-  ssm_later(ssm_to_sv(variables[0]), 1, DUMMY_VALUE);
+  ssm_later(variables[0], 1, DUMMY_VALUE);
 
   ssm_tick();
   printf("\n");
@@ -302,7 +302,7 @@ void trigger_basic() {
 
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
 
-  ssm_later(ssm_to_sv(variables[0]), 2, DUMMY_VALUE);
+  ssm_later(variables[0], 2, DUMMY_VALUE);
 
   step0ran = step1ran = false;
   ssm_tick();
@@ -314,7 +314,7 @@ void trigger_basic() {
 
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
 
-  ssm_later(ssm_to_sv(variables[0]), 3, DUMMY_VALUE);
+  ssm_later(variables[0], 3, DUMMY_VALUE);
   ssm_desensitize(&triggers[1]);
 
   step0ran = step1ran = false;
@@ -327,7 +327,7 @@ void trigger_basic() {
 
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
 
-  ssm_later(ssm_to_sv(variables[0]), 4, DUMMY_VALUE);
+  ssm_later(variables[0], 4, DUMMY_VALUE);
   ssm_desensitize(&triggers[0]);
 
   step0ran = step1ran = false;
@@ -340,7 +340,7 @@ void trigger_basic() {
 
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
 
-  ssm_later(ssm_to_sv(variables[0]), 5, DUMMY_VALUE);
+  ssm_later(variables[0], 5, DUMMY_VALUE);
   ssm_desensitize(&triggers[2]);
 
   step0ran = step1ran = false;
@@ -353,7 +353,7 @@ void trigger_basic() {
 
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
 
-  ssm_later(ssm_to_sv(variables[0]), 6, DUMMY_VALUE);
+  ssm_later(variables[0], 6, DUMMY_VALUE);
   ssm_sensitize(ssm_to_sv(variables[0]), &triggers[1]);
   ssm_sensitize(ssm_to_sv(variables[0]), &triggers[0]);
 
@@ -368,7 +368,7 @@ void trigger_basic() {
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
 
   ssm_desensitize(&triggers[0]);
-  ssm_later(ssm_to_sv(variables[0]), 7, DUMMY_VALUE);
+  ssm_later(variables[0], 7, DUMMY_VALUE);
 
   step0ran = step1ran = false;
   ssm_tick();

--- a/test/test-scheduler.c
+++ b/test/test-scheduler.c
@@ -287,9 +287,9 @@ void trigger_basic() {
 
   step0ran = step1ran = false;
 
-  ssm_sensitize(ssm_to_sv(variables[0]), &triggers[0]);
-  ssm_sensitize(ssm_to_sv(variables[0]), &triggers[1]);
-  ssm_sensitize(ssm_to_sv(variables[0]), &triggers[2]);
+  ssm_sensitize(variables[0], &triggers[0]);
+  ssm_sensitize(variables[0], &triggers[1]);
+  ssm_sensitize(variables[0], &triggers[2]);
 
   ssm_later(variables[0], 1, DUMMY_VALUE);
 
@@ -354,8 +354,8 @@ void trigger_basic() {
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
 
   ssm_later(variables[0], 6, DUMMY_VALUE);
-  ssm_sensitize(ssm_to_sv(variables[0]), &triggers[1]);
-  ssm_sensitize(ssm_to_sv(variables[0]), &triggers[0]);
+  ssm_sensitize(variables[0], &triggers[1]);
+  ssm_sensitize(variables[0], &triggers[0]);
 
   step0ran = step1ran = false;
   ssm_tick();
@@ -380,7 +380,7 @@ void trigger_basic() {
 
   SSM_ASSERT(ssm_next_event_time() == SSM_NEVER);
 
-  ssm_sensitize(ssm_to_sv(variables[0]), &triggers[0]);
+  ssm_sensitize(variables[0], &triggers[0]);
 
   for (ssm_trigger_t *trig = ssm_to_sv(variables[0])->triggers; trig;
        trig = trig->next)


### PR DESCRIPTION
Fix #23 

I introduce `_unsafe` versions of `assign` and `later` which mostly stay the same, i.e., they don't do automatic reference counting. A smart compiler could take advantage of this to only reference count where necessary, without a heap check.

The one infelicity here is that `ssm_later_unsafe` still calls `drop` on overwritten `later_value`s. It seemed cumbersome to expose that to the user, especially since that is considered the slow path anyway.