### PR TITLE
Revert change to ssm_active() (breaks POSIX example!)

### DIFF
--- a/src/ssm-scheduler.c
+++ b/src/ssm-scheduler.c
@@ -266,7 +266,9 @@ static size_t num_processes = 0;
 
 ssm_time_t ssm_now(void) { return now; }
 
-bool ssm_active(void) { return num_processes > 0; }
+// FIXME: Doesn't work well with handlers!
+// bool ssm_active(void) { return num_processes > 0; }
+bool ssm_active(void) { return act_queue_len > 0; }
 
 ssm_act_t *ssm_enter(size_t size, ssm_stepf_t step, ssm_act_t *parent,
                      ssm_priority_t priority, ssm_depth_t depth) {


### PR DESCRIPTION
Using `num_processes` is probably closer to the right thing to do, but it breaks all the regression tests in sslc. For now, I'll leave the POSIX example broken and deal with that later once I've thought about it more.